### PR TITLE
Wrap game/hands/{pid} response into a hash to be more like a RESTful show endpoint

### DIFF
--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -19,7 +19,7 @@ export default function configureEndpoints(server) {
 
       handler: (request, reply) => {
         const hand = game.getHand(request.params.pid);
-        reply(hand);
+        reply({pid: request.params.pid, hand: hand});
       },
     },
   });


### PR DESCRIPTION
@ArkadyDR 

I am using a Ruby library to automatically build a RESTful client based on your swagger docs.
But, it's pretty strict about the way it expects the endpoints to look.

For the GET games/hands/{pid} endpoint, we need to either;
- wrap up the result into a hash (currently, it returns an array of cards) -- so it is more like a #show
- change the URL to be like /games/hands?pid={pid} -- so it is more like an #index with a filter

I've decided to go with the first option and made those changes in this PR.
What do you think?